### PR TITLE
Fixed grammar incorrectness in  likes and replies yml

### DIFF
--- a/locale/flarum-likes.yml
+++ b/locale/flarum-likes.yml
@@ -12,7 +12,7 @@ flarum-likes:
       post_liked_text: '{username} vindt je bericht leuk'
     post:
       like_link: 'Vind ik leuk'
-      liked_by_self_text: '{users} vinden dit leuk.'
+      liked_by_self_text: '{count, plural, one {{users} vindt dit leuk} other {{users} vinden dit leuk}}'
       liked_by_text: '{count, plural, one {{users} vindt dit leuk} other {{users} vinden dit leuk}}'
       others_link: '=> core.ref.some_others'
       unlike_link: 'Niet leuk'

--- a/locale/flarum-mentions.yml
+++ b/locale/flarum-mentions.yml
@@ -23,8 +23,8 @@ flarum-mentions:
       post_mentioned_text: '{username} heeft gereageerd op je bericht'
       user_mentioned_text: '{username} heeft je genoemd'
     post:
-      mentioned_by_self_text: '{users} hebben hierop gereageerd.'
-      mentioned_by_text: '{users} hebben hierop gereageerd.'
+      mentioned_by_self_text: '{count, plural, one {{users} hebt hierop gereageerd} other {{users} hebben hierop gereageerd}}'
+      mentioned_by_text: '{count, plural, one {{users} heeft hierop gereageerd} other {{users} hebben hierop gereageerd}}'
       others_text: '=> core.ref.some_others'
       quote_button: Citeer
       reply_link: '=> core.ref.reply'


### PR DESCRIPTION
adjusted flarum-likes.yml and flarum-mentions.yml

Before change:

"Jij hebben hierop gereageerd" en "Jij vinden dit leuk"

After change:

"Jij hebt hierop gereageerd" en " Jij vindt dit leuk"